### PR TITLE
Move classnames module to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   },
   "dependencies": {
     "js-stylesheet": "0.0.1",
-    "react-resize-detector": "^0.3.0"
+    "react-resize-detector": "^0.3.0",
+    "classnames": "^2.2.3"
   },
   "devDependencies": {
     "babel-cli": "^6.5.1",
@@ -20,7 +21,6 @@
     "babel-plugin-transform-object-assign": "^6.5.0",
     "babel-preset-es2015": "^6.6.0",
     "babel-preset-react": "^6.3.13",
-    "classnames": "^2.2.3",
     "eslint": "^2.7.0",
     "eslint-config-airbnb": "^9.0.1",
     "eslint-plugin-import": "^1.0.3",


### PR DESCRIPTION
At the moment `classnames` module is in the `devDependencies`. Should be moved to runtime `dependencies`, as it's required in a component.

```
Error: Cannot find module 'classnames' from '/www/node_modules/react-responsive-tabs/lib/components'
```