### PR TITLE
More robust check DOM availability in a client

### DIFF
--- a/src/components/Tabs.js
+++ b/src/components/Tabs.js
@@ -12,7 +12,7 @@ import styles from '../styles/style';
 const tabPrefix = 'tab-';
 const panelPrefix = 'panel-';
 
-if (typeof window !== 'undefined') {
+if (window && window.document) {
   jss(styles);
 }
 

--- a/src/components/Tabs.js
+++ b/src/components/Tabs.js
@@ -12,7 +12,7 @@ import styles from '../styles/style';
 const tabPrefix = 'tab-';
 const panelPrefix = 'panel-';
 
-if (window && window.document) {
+if (typeof window !== 'undefined' && typeof window.document !== 'undefined') {
   jss(styles);
 }
 


### PR DESCRIPTION
Sometimes `window` could be mocked to `global` variable. As JS-Stylesheet module tries to access to the DOM methods, like `getElementById`, we have to check for window document instead.