### PR TITLE
Fixes bug where the first tab would not be selected when pushing enter

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -195,7 +195,7 @@ export default class Tabs extends Component {
   }
 
   _onKeyDown(event) {
-    if (event.keyCode === 13 && this.state.focusedTabKey) {
+    if (event.keyCode === 13 && this.state.focusedTabKey !== null) {
       this.setState({ selectedTabKey: this.state.focusedTabKey });
     }
   }


### PR DESCRIPTION
Hi!

This fixes a bug where the first tab could not be selected when focusing on it and pressing enter key, due to type-coercion (0 == false) in the null check.