### PR TITLE
Fixed TabPanel shouldComponentUpdate not respecting getContent property

### DIFF
--- a/src/components/TabPanel.js
+++ b/src/components/TabPanel.js
@@ -2,7 +2,8 @@ import React, { PureComponent, PropTypes } from 'react';
 
 export default class TabPanel extends PureComponent {
   shouldComponentUpdate(nextProps) {
-    return this.props.children !== nextProps.children ||
+    return this.props.getContent !== nextProps.getContent ||
+      this.props.children !== nextProps.children ||
       this.props.classNames !== nextProps.classNames ||
       this.props.selected !== nextProps.selected;
   }

--- a/src/index.js
+++ b/src/index.js
@@ -215,14 +215,14 @@ export default class Tabs extends PureComponent {
       >
         {panels.reduce((result, panel) => {
           if (tabsVisible[panel.key]) {
-            result.push(<Tab {...this.getTabProps(tabsVisible[panel.key]) } />);
+            result.push(<Tab {...this.getTabProps(tabsVisible[panel.key])} />);
           }
-          result.push(<TabPanel {...this.getPanelProps(panel) } />);
+          result.push(<TabPanel {...this.getPanelProps(panel)} />);
           return result;
         }, [])}
 
         <ShowMore ref={e => (this.tabsShowMore = e)} isShown={this.props.showMore}>
-          {tabsHidden.map(tab => <Tab {...this.getTabProps(tab) } />)}
+          {tabsHidden.map(tab => <Tab {...this.getTabProps(tab)} />)}
         </ShowMore>
 
         {(this.props.showMore || this.props.transform) &&

--- a/src/index.js
+++ b/src/index.js
@@ -215,14 +215,14 @@ export default class Tabs extends PureComponent {
       >
         {panels.reduce((result, panel) => {
           if (tabsVisible[panel.key]) {
-            result.push(<Tab {...this.getTabProps(tabsVisible[panel.key])} />);
+            result.push(<Tab {...this.getTabProps(tabsVisible[panel.key]) } />);
           }
-          result.push(<TabPanel {...this.getPanelProps(panel)} />);
+          result.push(<TabPanel {...this.getPanelProps(panel) } />);
           return result;
         }, [])}
 
         <ShowMore ref={e => (this.tabsShowMore = e)} isShown={this.props.showMore}>
-          {tabsHidden.map(tab => <Tab {...this.getTabProps(tab)} />)}
+          {tabsHidden.map(tab => <Tab {...this.getTabProps(tab) } />)}
         </ShowMore>
 
         {(this.props.showMore || this.props.transform) &&


### PR DESCRIPTION
Resolves https://github.com/maslianok/react-responsive-tabs/issues/16. Sorry about the minor format change. Must have been something introduced from vscode's auto-formatter. 

This will trigger re-render when the referenced getContent function is changed. This is required when the getContent resolves to a component with internal state that affects rendering. 