### PR TITLE
replace PureComponent to Component

### DIFF
--- a/src/components/ShowMore.js
+++ b/src/components/ShowMore.js
@@ -1,10 +1,10 @@
 /* eslint jsx-a11y/no-noninteractive-element-interactions: 0, jsx-a11y/no-noninteractive-tabindex: 0 */
 
-import React, { PureComponent } from 'react';
+import React, { Component } from 'react';
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
 
-export default class ShowMore extends PureComponent {
+export default class ShowMore extends Component {
   constructor() {
     super();
 

--- a/src/components/Tab.js
+++ b/src/components/Tab.js
@@ -1,11 +1,11 @@
-import React, { PureComponent } from 'react';
+import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 
 function onTabClick(selected, onClick, originalKey) {
   return () => !selected && onClick(originalKey);
 }
 
-export default class Tab extends PureComponent {
+export default class Tab extends Component {
   shouldComponentUpdate(nextProps) {
     return this.props.children !== nextProps.children ||
       this.props.selected !== nextProps.selected ||

--- a/src/components/TabPanel.js
+++ b/src/components/TabPanel.js
@@ -1,7 +1,7 @@
-import React, { PureComponent } from 'react';
+import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 
-export default class TabPanel extends PureComponent {
+export default class TabPanel extends Component {
   shouldComponentUpdate(nextProps) {
     return this.props.getContent !== nextProps.getContent ||
       this.props.children !== nextProps.children ||

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-import React, { PureComponent } from 'react';
+import React, { Component } from 'react';
 import ResizeDetector from 'react-resize-detector';
 import cs from 'classnames';
 import throttle from 'lodash.throttle';
@@ -11,7 +11,7 @@ import InkBar from './components/InkBar';
 const tabPrefix = 'tab-';
 const panelPrefix = 'panel-';
 
-export default class Tabs extends PureComponent {
+export default class Tabs extends Component {
   constructor(props) {
     super(props);
 


### PR DESCRIPTION
In react 16, its throwing warning 
```
Tabs has a method called shouldComponentUpdate(). shouldComponentUpdate should not be used when extending React.PureComponent. Please extend React.Component if shouldComponentUpdate is used.
``` 
So I replaced PureComponent to Component. 