### PR TITLE
Improve display when there is ShowMore

### DIFF
--- a/src/components/ShowMore.js
+++ b/src/components/ShowMore.js
@@ -25,6 +25,7 @@ export default class ShowMore extends Component {
     return (
       this.props.children.length !== nextProps.children.length ||
       this.props.isShown !== nextProps.isShown ||
+      this.props.hasChildSelected !== nextProps.hasChildSelected ||
       this.state !== nextState
     );
   }
@@ -63,12 +64,17 @@ export default class ShowMore extends Component {
   };
 
   render() {
-    const { isShown, children, onShowMoreChanged } = this.props;
+    const { isShown, children, onShowMoreChanged, hasChildSelected } = this.props;
     if (!isShown || !children || !children.length) {
       return null;
     }
 
     const isListHidden = this.state.isHidden;
+    const showMoreStyles = classNames({
+      RRT__showmore: true,
+      'RRT__showmore--selected': hasChildSelected
+    });
+
     const listStyles = classNames({
       'RRT__showmore-list': true,
       'RRT__showmore-list--opened': !isListHidden,
@@ -82,7 +88,7 @@ export default class ShowMore extends Component {
     return (
       <div
         ref={onShowMoreChanged}
-        className="RRT__showmore"
+        className={showMoreStyles}
         role="navigation"
         tabIndex="0"
         onFocus={this.onFocus}
@@ -100,11 +106,13 @@ export default class ShowMore extends Component {
 
 ShowMore.propTypes = {
   children: PropTypes.oneOfType([PropTypes.array, PropTypes.object, PropTypes.string]),
+  hasChildSelected: PropTypes.bool,
   isShown: PropTypes.bool.isRequired,
   onShowMoreChanged: PropTypes.func,
 };
 
 ShowMore.defaultProps = {
   children: undefined,
+  hasChildSelected: false,
   onShowMoreChanged: () => null,
 };

--- a/src/index.js
+++ b/src/index.js
@@ -163,6 +163,7 @@ export default class Tabs extends Component {
           result.tabsVisible.push(tabPayload);
         } else {
           result.tabsHidden.push(tabPayload);
+          if (selected) result.isSelectedTabHidden = true;
         }
         /* eslint-enable no-param-reassign */
 
@@ -171,7 +172,7 @@ export default class Tabs extends Component {
 
         return result;
       },
-      { tabsVisible: [], tabsHidden: [], panels: {} },
+      { tabsVisible: [], tabsHidden: [], panels: {}, isSelectedTabHidden: false },
     );
   };
 
@@ -253,7 +254,7 @@ export default class Tabs extends Component {
   render() {
     const { showInkBar, containerClass, tabsWrapperClass, showMore, transform, transformWidth } = this.props;
     const { tabDimensions, blockWidth } = this.state;
-    const { tabsVisible, tabsHidden, panels } = this.getTabs();
+    const { tabsVisible, tabsHidden, panels, isSelectedTabHidden } = this.getTabs();
     const collapsed = blockWidth && transform && blockWidth < transformWidth;
     const selectedTabKey = this.getSelectedTabKey();
     const selectedTabDimensions = tabDimensions[selectedTabKey] || {};
@@ -281,7 +282,9 @@ export default class Tabs extends Component {
         </div>
 
         {showInkBar &&
-        !collapsed && <InkBar left={selectedTabDimensions.offset || 0} width={selectedTabDimensions.width || 0} />}
+        !collapsed &&
+        !isSelectedTabHidden &&
+          <InkBar left={selectedTabDimensions.offset || 0} width={selectedTabDimensions.width || 0} />}
 
         {!collapsed && panels[selectedTabKey] && <TabPanel {...this.getPanelProps(panels[selectedTabKey])} />}
 

--- a/src/index.js
+++ b/src/index.js
@@ -205,6 +205,12 @@ export default class Tabs extends Component {
     classNames: this.getClassNamesFor('panel', { className }),
   });
 
+  getShowMoreProps = (isShown, isSelectedTabHidden) => ({
+    onShowMoreChanged: this.showMoreChanged,
+    isShown,
+    hasChildSelected: isSelectedTabHidden
+  });
+
   getClassNamesFor = (type, { selected, collapsed, tabIndex, disabled, className = '' }) => {
     switch (type) {
       case 'tab':
@@ -275,7 +281,7 @@ export default class Tabs extends Component {
           }, [])}
 
           {!collapsed && (
-            <ShowMore onShowMoreChanged={this.showMoreChanged} isShown={showMore}>
+            <ShowMore {...this.getShowMoreProps(showMore, isSelectedTabHidden)}>
               {tabsHidden.map(tab => <Tab {...this.getTabProps(tab)} />)}
             </ShowMore>
           )}

--- a/styles.css
+++ b/styles.css
@@ -82,6 +82,11 @@
   position: relative;
 }
 
+.RRT__showmore--selected {
+  background: white;
+  border-bottom: none;
+}
+
 .RRT__showmore-label {
   padding: .7em 1em;
   position: relative;


### PR DESCRIPTION
## Summary
* fix InkBar display incorrectly when selected tab is hidden in ShowMore https://github.com/maslianok/react-responsive-tabs/issues/24
* highlight ShowMore when selected tab is hidden inside it
![tabs](https://user-images.githubusercontent.com/15865062/33795836-69b19b3a-dd1b-11e7-9a1c-99851dcddf43.gif)


## Significant changes
* add boolean prop `hasChildSelected` to `ShowMore` to indicate when the selected tab is hidden inside it