### PR TITLE
allow to pass a translation component with proptype node on to show m…

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ render(<App />, document.getElementById('root'));
 | onChange         | Function      | onChange callback                                                            | undefined |
 | selectedTabKey   | Number/String | Selected tab                                                                 | undefined |
 | showMore         | Bool          | Whether to show `Show more` or not                                           | `true`    |
-| showMoreLabel    | String        | `Show more` tab name                                                         | `...`     |
+| showMoreLabel    | String/Node   | `Show more` tab name                                                         | `...`     |
 | transform        | Bool          | Transform to accordion when the wrapper width is less than `transformWidth`. | `true`    |
 | transformWidth   | Number        | Transform width.                                                             | 800       |
 | tabsWrapperClass | String        | Wrapper class                                                                | undefined |

--- a/src/components/ShowMore.js
+++ b/src/components/ShowMore.js
@@ -115,7 +115,10 @@ ShowMore.propTypes = {
   hasChildSelected: PropTypes.bool,
   isShown: PropTypes.bool.isRequired,
   onShowMoreChanged: PropTypes.func,
-  label: PropTypes.string
+  label: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.node,
+  ]),
 };
 
 ShowMore.defaultProps = {

--- a/src/index.js
+++ b/src/index.js
@@ -374,7 +374,10 @@ Tabs.propTypes = {
   tabClass: PropTypes.string,
   panelClass: PropTypes.string,
   // labels
-  showMoreLabel: PropTypes.string
+  showMoreLabel: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.node,
+  ]),
 };
 
 Tabs.defaultProps = {


### PR DESCRIPTION
allow to pass a translation component with proptype node on to show more tab...
Hi there, we have a case that we need to pass a component which translates dynamically the show more label in different languages and has an editorial wrapper around it. Thus we get proptype-warnings since we pass a node and not a string. Let me know wether everything is alright with the implementation or if I should change something :) thanks!