### PR TITLE
Item is object, checking object equality with '===' will not get expected result.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -65,7 +65,7 @@ export default class Tabs extends Component {
     if (
       uid !== prevProps.uid ||
       items.length !== prevProps.items.length ||
-      items.every((item, i) => item !== prevProps.items[i])
+      items.every((item, i) => item.title !== prevProps.items[i].title)
     ) {
       this.setTabsDimensions();
     }


### PR DESCRIPTION
Fix with just check the title changes or not, as the tab width is just related to the title.